### PR TITLE
Add `useNavigation` hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,12 +120,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - artifact-name: react-testing-library.rbxm
-            path: build/react-testing-library.rbxm
+          - artifact-name: roact-navigation.rbxm
+            path: build/roact-navigation.rbxm
             asset-type: application/octet-stream
 
-          - artifact-name: react-testing-library-dev.rbxm
-            path: build/debug/react-testing-library.rbxm
+          - artifact-name: roact-navigation-dev.rbxm
+            path: build/debug/roact-navigation.rbxm
             asset-type: application/octet-stream
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Tests
 "on":
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Work in progress, to be added to next release notes.
 
 ### v0.5.10
 
+* Added `useNavigation` hook to the module's export ([#2](https://github.com/jsdotlua/roact-navigation/pull/2))
 * Added "non-transparent, see-through card" support to RobloxStackView ([#148](https://github.com/Roblox/roact-navigation-internal/pull/148))
 
 ### v0.5.9

--- a/src/init.lua
+++ b/src/init.lua
@@ -14,6 +14,7 @@ return {
 
 	withNavigation = require("./views/withNavigation"),
 	withNavigationFocus = require("./views/withNavigationFocus"),
+	useNavigation = require("./views/useNavigation"),
 
 	-- Navigators
 	createRobloxStackNavigator = require("./navigators/createRobloxStackNavigator"),

--- a/src/routers/_tests_/createConfigGetter.spec.lua
+++ b/src/routers/_tests_/createConfigGetter.spec.lua
@@ -4,8 +4,6 @@ local React = require("@pkg/@jsdotlua/react")
 local JestGlobals = require("@pkg/@jsdotlua/jest-globals")
 local expect = JestGlobals.expect
 local it = JestGlobals.it
-local describe = JestGlobals.describe
-local beforeEach = JestGlobals.beforeEach
 
 local createConfigGetter = require("../createConfigGetter")
 

--- a/src/routers/_tests_/pathToRegexp.spec.lua
+++ b/src/routers/_tests_/pathToRegexp.spec.lua
@@ -9,7 +9,6 @@ local JestGlobals = require("@pkg/@jsdotlua/jest-globals")
 local expect = JestGlobals.expect
 local it = JestGlobals.it
 local describe = JestGlobals.describe
-local beforeEach = JestGlobals.beforeEach
 local pathToRegexp = require("../pathToRegexp")
 
 local undefined = {}


### PR DESCRIPTION
It looks like the useNavigation hook was missing from the exported content. Fixed that!

- [x] add entry to the changelog
